### PR TITLE
Process execution in different consortia

### DIFF
--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/ConstantsDataTransfer.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/ConstantsDataTransfer.java
@@ -10,6 +10,9 @@ public interface ConstantsDataTransfer
 	String PROCESS_NAME_FULL_DATA_SEND = ConstantsBase.PROCESS_MII_NAME_BASE + PROCESS_NAME_DATA_SEND;
 	String PROCESS_NAME_FULL_DATA_RECEIVE = ConstantsBase.PROCESS_MII_NAME_BASE + PROCESS_NAME_DATA_RECEIVE;
 
+	String PROCESS_URL_DATA_SEND = "http://medizininformatik-initiative.de/bpe/Process/dataSend";
+	String PROCESS_URL_DATA_RECEIVE = "http://medizininformatik-initiative.de/bpe/Process/dataReceive";
+
 	String PROFILE_TASK_DATA_SEND_START = "http://medizininformatik-initiative.de/fhir/StructureDefinition/task-data-send-start";
 	String PROFILE_TASK_DATA_SEND_START_PROCESS_URI = ConstantsBase.PROCESS_MII_URI_BASE + PROCESS_NAME_DATA_SEND;
 	String PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME = "dataSendStart";
@@ -23,7 +26,8 @@ public interface ConstantsDataTransfer
 	String PROFILE_TASK_DATA_STATUS_MESSAGE_NAME = "dataStatus";
 
 	String BPMN_EXECUTION_VARIABLE_PROJECT_IDENTIFIER = "projectIdentifier";
-	String BPMN_EXECUTION_VARIABLE_DMS_IDENTIFIER = "dms-identifier";
+	String BPMN_EXECUTION_VARIABLE_CONSORTIUM_IDENTIFIER = "consortiumIdentifier";
+	String BPMN_EXECUTION_VARIABLE_DMS_IDENTIFIER = "dmsIdentifier";
 	String BPMN_EXECUTION_VARIABLE_INITIAL_DOCUMENT_REFERENCE = "initialDocumentReference";
 	String BPMN_EXECUTION_VARIABLE_TRANSFER_DOCUMENT_REFERENCE = "transferDocumentReference";
 	String BPMN_EXECUTION_VARIABLE_TRANSFER_DOCUMENT_REFERENCE_LOCATION = "transferDocumentReferenceLocation";
@@ -36,10 +40,16 @@ public interface ConstantsDataTransfer
 	String BPMN_EXECUTION_VARIABLE_DATA_RECEIVE_ERROR_MESSAGE = "dataReceiveErrorMessage";
 
 	String CODESYSTEM_DATA_TRANSFER = "http://medizininformatik-initiative.de/fhir/CodeSystem/data-transfer";
+	String CODESYSTEM_DATA_TRANSFER_VALUE_CONSORTIUM_IDENTIFIER = "consortium-identifier";
 	String CODESYSTEM_DATA_TRANSFER_VALUE_DMS_IDENTIFIER = "dms-identifier";
 	String CODESYSTEM_DATA_TRANSFER_VALUE_PROJECT_IDENTIFIER = "project-identifier";
 	String CODESYSTEM_DATA_TRANSFER_VALUE_DOCUMENT_REFERENCE_LOCATION = "document-reference-location";
 	String CODESYSTEM_DATA_TRANSFER_VALUE_DATA_SET_STATUS = "data-set-status";
+
+	String CODE_SYSTEM_ORGANIZATION_ROLE = "http://dsf.dev/fhir/CodeSystem/organization-role";
+	String CODE_SYSTEM_PRACTITIONER_ROLE = "http://dsf.dev/fhir/CodeSystem/practitioner-role";
+	String CODE_SYSTEM_PRACTITIONER_ROLE_VALUE_DSF_ADMIN = "DSF_ADMIN";
+
 
 	String EXTENSION_LIST_ENTRY_MIMETYPE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/extension-list-entry-item-mimetype";
 }

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/ConstantsDataTransfer.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/ConstantsDataTransfer.java
@@ -50,6 +50,5 @@ public interface ConstantsDataTransfer
 	String CODE_SYSTEM_PRACTITIONER_ROLE = "http://dsf.dev/fhir/CodeSystem/practitioner-role";
 	String CODE_SYSTEM_PRACTITIONER_ROLE_VALUE_DSF_ADMIN = "DSF_ADMIN";
 
-
 	String EXTENSION_LIST_ENTRY_MIMETYPE = "http://medizininformatik-initiative.de/fhir/StructureDefinition/extension-list-entry-item-mimetype";
 }

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/DataTransferProcessPluginDeploymentStateListener.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/DataTransferProcessPluginDeploymentStateListener.java
@@ -9,6 +9,7 @@ import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.MetadataResource;
 import org.springframework.beans.factory.InitializingBean;
 
+import de.medizininformatik_initiative.process.data_transfer.authorization.AuthorizationProvider;
 import de.medizininformatik_initiative.processes.common.crypto.KeyProvider;
 import de.medizininformatik_initiative.processes.common.fhir.client.FhirClientFactory;
 import de.medizininformatik_initiative.processes.common.util.MetadataResourceConverter;
@@ -26,16 +27,18 @@ public class DataTransferProcessPluginDeploymentStateListener
 	private final KeyProvider keyProvider;
 
 	private final MetadataResourceConverter metadataResourceConverter;
+	private final AuthorizationProvider authorizationProvider;
 
 	public DataTransferProcessPluginDeploymentStateListener(ProcessPluginApi api,
 			FhirClientFactory dicFhirClientFactory, FhirClientFactory dmsFhirClientConfig, KeyProvider keyProvider,
-			MetadataResourceConverter metadataResourceConverter)
+			MetadataResourceConverter metadataResourceConverter, AuthorizationProvider authorizationProvider)
 	{
 		this.api = api;
 		this.dicFhirClientFactory = dicFhirClientFactory;
 		this.dmsFhirClientFactory = dmsFhirClientConfig;
 		this.keyProvider = keyProvider;
 		this.metadataResourceConverter = metadataResourceConverter;
+		this.authorizationProvider = authorizationProvider;
 	}
 
 	@Override
@@ -46,6 +49,7 @@ public class DataTransferProcessPluginDeploymentStateListener
 		Objects.requireNonNull(dmsFhirClientFactory, "dmsFhirClientFactory");
 		Objects.requireNonNull(keyProvider, "keyProvider");
 		Objects.requireNonNull(metadataResourceConverter, "metadataResourceConverter");
+		Objects.requireNonNull(authorizationProvider, "authorizationProvider");
 	}
 
 	@Override
@@ -60,10 +64,14 @@ public class DataTransferProcessPluginDeploymentStateListener
 				this::filterCodeSystemsWithNonMatchingConceptCodes, this::adaptCodeSystemsReplacingConcepts);
 
 		if (activeProcesses.contains(ConstantsDataTransfer.PROCESS_NAME_FULL_DATA_SEND))
+		{
+			authorizationProvider.searchCheckAddAndUpdateAuthorizationDataSend();
 			dicFhirClientFactory.testConnection();
+		}
 
 		if (activeProcesses.contains(ConstantsDataTransfer.PROCESS_NAME_FULL_DATA_RECEIVE))
 		{
+			authorizationProvider.searchCheckAddAndUpdateAuthorizationDataReceive();
 			dmsFhirClientFactory.testConnection();
 			keyProvider.createPublicKeyIfNotExists();
 		}

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/authorization/AuthorizationProvider.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/authorization/AuthorizationProvider.java
@@ -215,7 +215,7 @@ public class AuthorizationProvider implements InitializingBean
 					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS, toRequesterString(removedOldRequestersDataStatus));
 			logger.info(
-					"Adjsuting allowed data-set receivers to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					"Adjusting allowed data-set receivers to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
 					ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS, toRecipientString(removedOldRecipientsDataStatus));

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/authorization/AuthorizationProvider.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/authorization/AuthorizationProvider.java
@@ -1,0 +1,315 @@
+package de.medizininformatik_initiative.process.data_transfer.authorization;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.hl7.fhir.r4.model.ActivityDefinition;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+
+import de.medizininformatik_initiative.process.data_transfer.ConstantsDataTransfer;
+import dev.dsf.bpe.v1.ProcessPluginApi;
+import dev.dsf.fhir.authorization.process.ProcessAuthorizationHelper;
+import dev.dsf.fhir.authorization.process.Recipient;
+import dev.dsf.fhir.authorization.process.Requester;
+
+public class AuthorizationProvider implements InitializingBean
+{
+	private static final Logger logger = LoggerFactory.getLogger(AuthorizationProvider.class);
+
+	private record ProcessAuthorization(String parentOrganizationIdentifierValue, String organizationRoleCodingValue)
+	{
+		public static ProcessAuthorization from(String processAuthorization)
+		{
+			String[] identifierRoleSplit = processAuthorization.split("\\|");
+			if (identifierRoleSplit.length < 2)
+				throw new IllegalArgumentException(
+						"Process authorization configuration should be in format <parent-organization-identifier>|<role>, but does not contain '|'");
+
+			return new ProcessAuthorization(identifierRoleSplit[0], identifierRoleSplit[1]);
+		}
+	}
+
+	private final ProcessPluginApi api;
+
+	private final String resourcesVersion;
+
+	private final List<ProcessAuthorization> additionallyAllowedSenders;
+	private final List<ProcessAuthorization> additionallyAllowedReceivers;
+
+	public AuthorizationProvider(ProcessPluginApi api, String resourcesVersion, List<String> additionallyAllowedSenders,
+			List<String> additionallyAllowedReceivers)
+	{
+		this.api = api;
+		this.resourcesVersion = resourcesVersion;
+
+		this.additionallyAllowedSenders = additionallyAllowedSenders.stream().map(ProcessAuthorization::from).toList();
+		this.additionallyAllowedReceivers = additionallyAllowedReceivers.stream().map(ProcessAuthorization::from)
+				.toList();
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception
+	{
+		Objects.requireNonNull(api, "api");
+		Objects.requireNonNull(resourcesVersion, "resourcesVersion");
+
+		Objects.requireNonNull(additionallyAllowedSenders, "allowedSenders");
+		Objects.requireNonNull(additionallyAllowedReceivers, "allowedReceivers");
+	}
+
+	public void searchCheckAddAndUpdateAuthorizationDataSend()
+	{
+		searchCheckAddAndUpdateAuthorization(ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
+				this::checkAddAndUpdateAuthorizationDataSend);
+	}
+
+	public void searchCheckAddAndUpdateAuthorizationDataReceive()
+	{
+		searchCheckAddAndUpdateAuthorization(ConstantsDataTransfer.PROCESS_URL_DATA_RECEIVE, resourcesVersion,
+				this::checkAddAndUpdateAuthorizationDataReceive);
+	}
+
+	public void checkAddAndUpdateAuthorizationDataSend(ActivityDefinition activityDefinition)
+	{
+		// for each entry in allowedSender: check if exists or add requester for task-data-send-start (LOCAL_ROLE,
+		// LOCAL_ROLE_PRACTITIONER)
+		// for each entry in allowedSender: check if exists or add recipient for task-data-send-start (LOCAL_ROLE)
+		Set<Requester> requestersDataSendStart = api.getProcessAuthorizationHelper()
+				.getRequesters(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START)
+				.collect(Collectors.toSet());
+		Set<Recipient> recipientDataSendStart = api.getProcessAuthorizationHelper()
+				.getRecipients(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START)
+				.collect(Collectors.toSet());
+
+		List<Requester> missingRequesterDataSendStart = additionallyAllowedSenders.stream()
+				.flatMap(s -> Stream.of(
+						Requester.localRole(s.parentOrganizationIdentifierValue,
+								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue),
+						Requester.localRolePractitioner(s.parentOrganizationIdentifierValue,
+								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue,
+								ConstantsDataTransfer.CODE_SYSTEM_PRACTITIONER_ROLE,
+								ConstantsDataTransfer.CODE_SYSTEM_PRACTITIONER_ROLE_VALUE_DSF_ADMIN)))
+				.filter(notContainsNewRequester(requestersDataSendStart)).toList();
+		List<Recipient> missingRecipientDataSendStart = additionallyAllowedSenders.stream()
+				.map(s -> Recipient.localRole(s.parentOrganizationIdentifierValue,
+						ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue))
+				.filter(notContainsNewRecipient(recipientDataSendStart)).toList();
+
+		if (!missingRequesterDataSendStart.isEmpty() || !missingRecipientDataSendStart.isEmpty())
+		{
+			logger.info(
+					"Adding additional allowed data-set senders to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START,
+					toRequesterString(missingRequesterDataSendStart));
+			logger.info(
+					"Adding additional allowed data-set receivers to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START,
+					toRecipientString(missingRecipientDataSendStart));
+			api.getProcessAuthorizationHelper().add(activityDefinition,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME,
+					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START), missingRequesterDataSendStart,
+					missingRecipientDataSendStart);
+		}
+
+		// for each entry in allowedReceiver: check if exists or add requester for task-data-status (LOCAL_ROLE,
+		// REMOTE_ROLE)
+		// for each entry in allowedSender: check if exists or add recipient for task-data-status (LOCAL_ROLE)
+		Set<Requester> requestersDataStatus = api.getProcessAuthorizationHelper()
+				.getRequesters(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS)
+				.collect(Collectors.toSet());
+		Set<Recipient> recipientDataStatus = api.getProcessAuthorizationHelper()
+				.getRecipients(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS)
+				.collect(Collectors.toSet());
+
+		List<Requester> missingRequesterDataStatus = additionallyAllowedReceivers.stream()
+				.flatMap(s -> Stream.of(
+						Requester.localRole(s.parentOrganizationIdentifierValue,
+								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue),
+						Requester.remoteRole(s.parentOrganizationIdentifierValue,
+								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue)))
+				.filter(notContainsNewRequester(requestersDataStatus)).toList();
+		List<Recipient> missingRecipientDataStatus = additionallyAllowedSenders.stream()
+				.map(s -> Recipient.localRole(s.parentOrganizationIdentifierValue,
+						ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue))
+				.filter(notContainsNewRecipient(recipientDataStatus)).toList();
+
+		if (!missingRequesterDataStatus.isEmpty() || !missingRecipientDataStatus.isEmpty())
+		{
+			logger.info(
+					"Adding additional allowed data-set senders to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS, toRequesterString(missingRequesterDataStatus));
+			logger.info(
+					"Adding additional allowed data-set receivers to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS, toRecipientString(missingRecipientDataStatus));
+			api.getProcessAuthorizationHelper().add(activityDefinition,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
+					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS), missingRequesterDataStatus,
+					missingRecipientDataStatus);
+		}
+
+		if (!missingRequesterDataSendStart.isEmpty() || !missingRecipientDataSendStart.isEmpty()
+				|| !requestersDataStatus.isEmpty() || !recipientDataStatus.isEmpty())
+			updateResource(activityDefinition);
+	}
+
+	public void checkAddAndUpdateAuthorizationDataReceive(ActivityDefinition activityDefinition)
+	{
+		// for each entry in allowedSender: check if exists or add requester for task-data-send (LOCAL_ROLE,
+		// REMOTE_ROLE)
+		Set<Requester> requestersDataSend = api.getProcessAuthorizationHelper()
+				.getRequesters(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_RECEIVE, resourcesVersion,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND)
+				.collect(Collectors.toSet());
+
+		List<Requester> missingRequesterDataSend = additionallyAllowedSenders.stream()
+				.flatMap(s -> Stream.of(
+						Requester.localRole(s.parentOrganizationIdentifierValue,
+								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue),
+						Requester.remoteRole(s.parentOrganizationIdentifierValue,
+								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue)))
+				.filter(notContainsNewRequester(requestersDataSend)).toList();
+
+		// for each entry in allowedReceivers: check if exists or add recipient for task-data-status (LOCAL_ROLE)
+		Set<Recipient> recipientDataSend = api.getProcessAuthorizationHelper()
+				.getRecipients(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_RECEIVE, resourcesVersion,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME,
+						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND)
+				.collect(Collectors.toSet());
+
+		List<Recipient> missingRecipientDataSend = additionallyAllowedReceivers.stream()
+				.map(s -> Recipient.localRole(s.parentOrganizationIdentifierValue,
+						ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue))
+				.filter(notContainsNewRecipient(recipientDataSend)).toList();
+
+		if (!missingRequesterDataSend.isEmpty() || !missingRecipientDataSend.isEmpty())
+		{
+			logger.info(
+					"Adding additional allowed data-set senders to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					ConstantsDataTransfer.PROCESS_URL_DATA_RECEIVE, resourcesVersion,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND, toRequesterString(missingRequesterDataSend));
+			logger.info(
+					"Adding additional allowed data-set receivers to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					ConstantsDataTransfer.PROCESS_URL_DATA_RECEIVE, resourcesVersion,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND, toRecipientString(missingRecipientDataSend));
+			api.getProcessAuthorizationHelper().add(activityDefinition,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME,
+					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_SEND), missingRequesterDataSend,
+					missingRecipientDataSend);
+			updateResource(activityDefinition);
+		}
+	}
+
+	private void searchCheckAddAndUpdateAuthorization(String url, String version,
+			Consumer<ActivityDefinition> checkAddAndUpdateAuthorization)
+	{
+		Bundle searchResult = searchActivityDefinition(url, version);
+		extractActivityDefinition(searchResult).ifPresent(checkAddAndUpdateAuthorization);
+	}
+
+	private Bundle searchActivityDefinition(String url, String version)
+	{
+		return api.getFhirWebserviceClientProvider().getLocalWebserviceClient().search(ActivityDefinition.class,
+				Map.of("url", List.of(url), "version", List.of(version)));
+	}
+
+	private Optional<ActivityDefinition> extractActivityDefinition(Bundle bundle)
+	{
+		return bundle.getEntry().stream().filter(Bundle.BundleEntryComponent::hasResource)
+				.map(Bundle.BundleEntryComponent::getResource).filter(r -> r instanceof ActivityDefinition)
+				.map(r -> (ActivityDefinition) r).findFirst();
+	}
+
+	private void updateResource(Resource resource)
+	{
+		api.getFhirWebserviceClientProvider().getLocalWebserviceClient().update(resource);
+	}
+
+	private Predicate<Requester> notContainsNewRequester(Set<Requester> existings)
+	{
+		return newR -> existings.stream().noneMatch(existing -> existing.requesterMatches(newR.toRequesterExtension()));
+	}
+
+	private Predicate<Recipient> notContainsNewRecipient(Set<Recipient> existings)
+	{
+
+		return newR -> existings.stream().noneMatch(existing -> existing.recipientMatches(newR.toRecipientExtension()));
+	}
+
+	private String appendVersion(String url)
+	{
+		return url + "|" + resourcesVersion;
+	}
+
+	private String toRequesterString(List<Requester> requesters)
+	{
+		return requesters.stream().map(Requester::toRequesterExtension).map(Extension::getValue)
+				.filter(v -> v instanceof Coding).map(v -> (Coding) v).map(this::toParentOrganizationRoleString)
+				.collect(Collectors.joining(","));
+	}
+
+	private String toRecipientString(List<Recipient> recipients)
+	{
+		return recipients.stream().map(Recipient::toRecipientExtension).map(Extension::getValue)
+				.filter(v -> v instanceof Coding).map(v -> (Coding) v).map(this::toParentOrganizationRoleString)
+				.collect(Collectors.joining(", "));
+	}
+
+	private String toParentOrganizationRoleString(Coding coding)
+	{
+		Extension extension = Optional
+				.ofNullable(coding.getExtensionByUrl(
+						ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PARENT_ORGANIZATION_ROLE))
+				.orElseGet(() -> coding.getExtensionByUrl(
+						ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PARENT_ORGANIZATION_ROLE_PRACTITIONER));
+		String parentOrganization = getParentOrganizationIdentifierValue(extension);
+		String role = getRoleValue(extension);
+		return parentOrganization + "|" + role + "|" + coding.getCode();
+	}
+
+	private String getParentOrganizationIdentifierValue(Extension extension)
+	{
+		return ((Identifier) extension.getExtensionByUrl(
+				ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PARENT_ORGANIZATION_ROLE_PARENT_ORGANIZATION)
+				.getValue()).getValue();
+	}
+
+	private String getRoleValue(Extension extension)
+	{
+		return ((Coding) extension.getExtensionByUrl(
+				ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_PARENT_ORGANIZATION_ROLE_ORGANIZATION_ROLE)
+				.getValue()).getCode();
+	}
+}

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/authorization/AuthorizationProvider.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/authorization/AuthorizationProvider.java
@@ -1,5 +1,6 @@
 package de.medizininformatik_initiative.process.data_transfer.authorization;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -12,15 +13,18 @@ import java.util.stream.Stream;
 
 import org.hl7.fhir.r4.model.ActivityDefinition;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StringType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 
 import de.medizininformatik_initiative.process.data_transfer.ConstantsDataTransfer;
+import de.medizininformatik_initiative.processes.common.util.ConstantsBase;
 import dev.dsf.bpe.v1.ProcessPluginApi;
 import dev.dsf.fhir.authorization.process.ProcessAuthorizationHelper;
 import dev.dsf.fhir.authorization.process.Recipient;
@@ -56,7 +60,14 @@ public class AuthorizationProvider implements InitializingBean
 		this.api = api;
 		this.resourcesVersion = resourcesVersion;
 
+		additionallyAllowedSenders
+				.add(ConstantsBase.NAMINGSYSTEM_DSF_ORGANIZATION_IDENTIFIER_MEDICAL_INFORMATICS_INITIATIVE_CONSORTIUM
+						+ "|DIC");
 		this.additionallyAllowedSenders = additionallyAllowedSenders.stream().map(ProcessAuthorization::from).toList();
+
+		additionallyAllowedReceivers
+				.add(ConstantsBase.NAMINGSYSTEM_DSF_ORGANIZATION_IDENTIFIER_MEDICAL_INFORMATICS_INITIATIVE_CONSORTIUM
+						+ "|DMS");
 		this.additionallyAllowedReceivers = additionallyAllowedReceivers.stream().map(ProcessAuthorization::from)
 				.toList();
 	}
@@ -85,21 +96,23 @@ public class AuthorizationProvider implements InitializingBean
 
 	public void checkAddAndUpdateAuthorizationDataSend(ActivityDefinition activityDefinition)
 	{
+		boolean processAuthorizationChanged = false;
+
 		// for each entry in allowedSender: check if exists or add requester for task-data-send-start (LOCAL_ROLE,
 		// LOCAL_ROLE_PRACTITIONER)
 		// for each entry in allowedSender: check if exists or add recipient for task-data-send-start (LOCAL_ROLE)
-		Set<Requester> requestersDataSendStart = api.getProcessAuthorizationHelper()
+		Set<Requester> currentRequestersDataSendStart = api.getProcessAuthorizationHelper()
 				.getRequesters(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START)
 				.collect(Collectors.toSet());
-		Set<Recipient> recipientDataSendStart = api.getProcessAuthorizationHelper()
+		Set<Recipient> currentRecipientsDataSendStart = api.getProcessAuthorizationHelper()
 				.getRecipients(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START)
 				.collect(Collectors.toSet());
 
-		List<Requester> missingRequesterDataSendStart = additionallyAllowedSenders.stream()
+		Set<Requester> configuredRequestersDataSendStart = additionallyAllowedSenders.stream()
 				.flatMap(s -> Stream.of(
 						Requester.localRole(s.parentOrganizationIdentifierValue,
 								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue),
@@ -107,78 +120,117 @@ public class AuthorizationProvider implements InitializingBean
 								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue,
 								ConstantsDataTransfer.CODE_SYSTEM_PRACTITIONER_ROLE,
 								ConstantsDataTransfer.CODE_SYSTEM_PRACTITIONER_ROLE_VALUE_DSF_ADMIN)))
-				.filter(notContainsNewRequester(requestersDataSendStart)).toList();
-		List<Recipient> missingRecipientDataSendStart = additionallyAllowedSenders.stream()
+				.collect(Collectors.toSet());
+		Set<Recipient> configuredRecipientsDataSendStart = additionallyAllowedSenders.stream()
 				.map(s -> Recipient.localRole(s.parentOrganizationIdentifierValue,
 						ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue))
-				.filter(notContainsNewRecipient(recipientDataSendStart)).toList();
+				.collect(Collectors.toSet());
 
-		if (!missingRequesterDataSendStart.isEmpty() || !missingRecipientDataSendStart.isEmpty())
+		Set<Requester> removedOldRequestersDataSendStart = currentRequestersDataSendStart.stream()
+				.filter(containsOldRequester(configuredRequestersDataSendStart)).collect(Collectors.toSet());
+		Set<Recipient> removedOldRecipientsDataSendStart = currentRecipientsDataSendStart.stream()
+				.filter(containsOldRecipient(configuredRecipientsDataSendStart)).collect(Collectors.toSet());
+
+		Set<Requester> missingRequestersDataSendStart = configuredRequestersDataSendStart.stream()
+				.filter(notContainsNewRequester(removedOldRequestersDataSendStart)).collect(Collectors.toSet());
+		Set<Recipient> missingRecipientsDataSendStart = configuredRecipientsDataSendStart.stream()
+				.filter(notContainsNewRecipient(removedOldRecipientsDataSendStart)).collect(Collectors.toSet());
+
+		if (!missingRequestersDataSendStart.isEmpty() || !missingRecipientsDataSendStart.isEmpty()
+				|| removedOldRequestersDataSendStart.size() != currentRequestersDataSendStart.size()
+				|| removedOldRecipientsDataSendStart.size() != currentRecipientsDataSendStart.size())
 		{
+			removedOldRequestersDataSendStart.addAll(missingRequestersDataSendStart);
+			removedOldRecipientsDataSendStart.addAll(missingRecipientsDataSendStart);
+
 			logger.info(
-					"Adding additional allowed data-set senders to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					"Adjusting allowed data-set senders to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
 					ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START,
-					toRequesterString(missingRequesterDataSendStart));
+					toRequesterString(removedOldRequestersDataSendStart));
 			logger.info(
-					"Adding additional allowed data-set receivers to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					"Adjusting allowed data-set receivers to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
 					ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START,
-					toRecipientString(missingRecipientDataSendStart));
+					toRecipientString(removedOldRecipientsDataSendStart));
+
+			removeAllAuthorizationExtensions(activityDefinition,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME,
+					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START));
 			api.getProcessAuthorizationHelper().add(activityDefinition,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START_MESSAGE_NAME,
-					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START), missingRequesterDataSendStart,
-					missingRecipientDataSendStart);
+					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_START),
+					removedOldRequestersDataSendStart, removedOldRecipientsDataSendStart);
+			processAuthorizationChanged = true;
 		}
 
 		// for each entry in allowedReceiver: check if exists or add requester for task-data-status (LOCAL_ROLE,
 		// REMOTE_ROLE)
 		// for each entry in allowedSender: check if exists or add recipient for task-data-status (LOCAL_ROLE)
-		Set<Requester> requestersDataStatus = api.getProcessAuthorizationHelper()
+		Set<Requester> currentRequestersDataStatus = api.getProcessAuthorizationHelper()
 				.getRequesters(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS)
 				.collect(Collectors.toSet());
-		Set<Recipient> recipientDataStatus = api.getProcessAuthorizationHelper()
+		Set<Recipient> currentRecipientsDataStatus = api.getProcessAuthorizationHelper()
 				.getRecipients(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS)
 				.collect(Collectors.toSet());
 
-		List<Requester> missingRequesterDataStatus = additionallyAllowedReceivers.stream()
+		Set<Requester> configuredRequestersDataStatus = additionallyAllowedReceivers.stream()
 				.flatMap(s -> Stream.of(
 						Requester.localRole(s.parentOrganizationIdentifierValue,
 								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue),
 						Requester.remoteRole(s.parentOrganizationIdentifierValue,
 								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue)))
-				.filter(notContainsNewRequester(requestersDataStatus)).toList();
-		List<Recipient> missingRecipientDataStatus = additionallyAllowedSenders.stream()
+				.collect(Collectors.toSet());
+		Set<Recipient> configuredRecipientsDataStatus = additionallyAllowedSenders.stream()
 				.map(s -> Recipient.localRole(s.parentOrganizationIdentifierValue,
 						ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue))
-				.filter(notContainsNewRecipient(recipientDataStatus)).toList();
+				.collect(Collectors.toSet());
 
-		if (!missingRequesterDataStatus.isEmpty() || !missingRecipientDataStatus.isEmpty())
+		Set<Requester> removedOldRequestersDataStatus = currentRequestersDataStatus.stream()
+				.filter(containsOldRequester(configuredRequestersDataStatus)).collect(Collectors.toSet());
+		Set<Recipient> removedOldRecipientsDataStatus = currentRecipientsDataStatus.stream()
+				.filter(containsOldRecipient(configuredRecipientsDataStatus)).collect(Collectors.toSet());
+
+		Set<Requester> missingRequestersDataStatus = configuredRequestersDataStatus.stream()
+				.filter(notContainsNewRequester(removedOldRequestersDataStatus)).collect(Collectors.toSet());
+		Set<Recipient> missingRecipientsDataStatus = configuredRecipientsDataStatus.stream()
+				.filter(notContainsNewRecipient(removedOldRecipientsDataStatus)).collect(Collectors.toSet());
+
+		if (!missingRequestersDataStatus.isEmpty() || !missingRecipientsDataStatus.isEmpty()
+				|| removedOldRequestersDataStatus.size() != currentRequestersDataStatus.size()
+				|| removedOldRecipientsDataStatus.size() != currentRecipientsDataStatus.size())
 		{
+			removedOldRequestersDataStatus.addAll(missingRequestersDataStatus);
+			removedOldRecipientsDataStatus.addAll(missingRecipientsDataStatus);
+
 			logger.info(
-					"Adding additional allowed data-set senders to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					"Adjusting allowed data-set senders to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
 					ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
-					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS, toRequesterString(missingRequesterDataStatus));
+					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS, toRequesterString(removedOldRequestersDataStatus));
 			logger.info(
-					"Adding additional allowed data-set receivers to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					"Adjsuting allowed data-set receivers to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
 					ConstantsDataTransfer.PROCESS_URL_DATA_SEND, resourcesVersion,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
-					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS, toRecipientString(missingRecipientDataStatus));
+					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS, toRecipientString(removedOldRecipientsDataStatus));
+
+			removeAllAuthorizationExtensions(activityDefinition,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
+					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS));
 			api.getProcessAuthorizationHelper().add(activityDefinition,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS_MESSAGE_NAME,
-					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS), missingRequesterDataStatus,
-					missingRecipientDataStatus);
+					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_STATUS), removedOldRequestersDataStatus,
+					removedOldRecipientsDataStatus);
+			processAuthorizationChanged = true;
 		}
 
-		if (!missingRequesterDataSendStart.isEmpty() || !missingRecipientDataSendStart.isEmpty()
-				|| !requestersDataStatus.isEmpty() || !recipientDataStatus.isEmpty())
+		if (processAuthorizationChanged)
 			updateResource(activityDefinition);
 	}
 
@@ -186,48 +238,65 @@ public class AuthorizationProvider implements InitializingBean
 	{
 		// for each entry in allowedSender: check if exists or add requester for task-data-send (LOCAL_ROLE,
 		// REMOTE_ROLE)
-		Set<Requester> requestersDataSend = api.getProcessAuthorizationHelper()
+		// for each entry in allowedReceivers: check if exists or add recipient for task-data-status (LOCAL_ROLE)
+		Set<Requester> currentRequestersDataSend = api.getProcessAuthorizationHelper()
 				.getRequesters(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_RECEIVE, resourcesVersion,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND)
 				.collect(Collectors.toSet());
-
-		List<Requester> missingRequesterDataSend = additionallyAllowedSenders.stream()
-				.flatMap(s -> Stream.of(
-						Requester.localRole(s.parentOrganizationIdentifierValue,
-								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue),
-						Requester.remoteRole(s.parentOrganizationIdentifierValue,
-								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue)))
-				.filter(notContainsNewRequester(requestersDataSend)).toList();
-
-		// for each entry in allowedReceivers: check if exists or add recipient for task-data-status (LOCAL_ROLE)
-		Set<Recipient> recipientDataSend = api.getProcessAuthorizationHelper()
+		Set<Recipient> currentRecipientsDataSend = api.getProcessAuthorizationHelper()
 				.getRecipients(activityDefinition, ConstantsDataTransfer.PROCESS_URL_DATA_RECEIVE, resourcesVersion,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME,
 						ConstantsDataTransfer.PROFILE_TASK_DATA_SEND)
 				.collect(Collectors.toSet());
 
-		List<Recipient> missingRecipientDataSend = additionallyAllowedReceivers.stream()
+		Set<Requester> configuredRequestersDataSend = additionallyAllowedSenders.stream()
+				.flatMap(s -> Stream.of(
+						Requester.localRole(s.parentOrganizationIdentifierValue,
+								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue),
+						Requester.remoteRole(s.parentOrganizationIdentifierValue,
+								ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue)))
+				.collect(Collectors.toSet());
+		Set<Recipient> configuredRecipientsDataSend = additionallyAllowedReceivers.stream()
 				.map(s -> Recipient.localRole(s.parentOrganizationIdentifierValue,
 						ConstantsDataTransfer.CODE_SYSTEM_ORGANIZATION_ROLE, s.organizationRoleCodingValue))
-				.filter(notContainsNewRecipient(recipientDataSend)).toList();
+				.collect(Collectors.toSet());
 
-		if (!missingRequesterDataSend.isEmpty() || !missingRecipientDataSend.isEmpty())
+		Set<Requester> removedOldRequestersDataSend = currentRequestersDataSend.stream()
+				.filter(containsOldRequester(configuredRequestersDataSend)).collect(Collectors.toSet());
+		Set<Recipient> removedOldRecipientsDataSend = currentRecipientsDataSend.stream()
+				.filter(containsOldRecipient(configuredRecipientsDataSend)).collect(Collectors.toSet());
+
+		List<Requester> missingRequestersDataSend = configuredRequestersDataSend.stream()
+				.filter(notContainsNewRequester(removedOldRequestersDataSend)).toList();
+		List<Recipient> missingRecipientsDataSend = configuredRecipientsDataSend.stream()
+				.filter(notContainsNewRecipient(removedOldRecipientsDataSend)).toList();
+
+		if (!missingRequestersDataSend.isEmpty() || !missingRecipientsDataSend.isEmpty()
+				|| removedOldRequestersDataSend.size() != currentRequestersDataSend.size()
+				|| removedOldRecipientsDataSend.size() != currentRecipientsDataSend.size())
 		{
+			removedOldRequestersDataSend.addAll(missingRequestersDataSend);
+			removedOldRecipientsDataSend.addAll(missingRecipientsDataSend);
+
 			logger.info(
-					"Adding additional allowed data-set senders to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					"Adjusting allowed data-set senders to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
 					ConstantsDataTransfer.PROCESS_URL_DATA_RECEIVE, resourcesVersion,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME,
-					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND, toRequesterString(missingRequesterDataSend));
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND, toRequesterString(removedOldRequestersDataSend));
 			logger.info(
-					"Adding additional allowed data-set receivers to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
+					"Adjusting allowed data-set receivers to the authorization rules for process '{}', version '{}', message-name '{}' and task-profile '{}': {}",
 					ConstantsDataTransfer.PROCESS_URL_DATA_RECEIVE, resourcesVersion,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME,
-					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND, toRecipientString(missingRecipientDataSend));
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND, toRecipientString(removedOldRecipientsDataSend));
+
+			removeAllAuthorizationExtensions(activityDefinition,
+					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME,
+					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_SEND));
 			api.getProcessAuthorizationHelper().add(activityDefinition,
 					ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME,
-					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_SEND), missingRequesterDataSend,
-					missingRecipientDataSend);
+					appendVersion(ConstantsDataTransfer.PROFILE_TASK_DATA_SEND), removedOldRequestersDataSend,
+					removedOldRecipientsDataSend);
 			updateResource(activityDefinition);
 		}
 	}
@@ -257,6 +326,18 @@ public class AuthorizationProvider implements InitializingBean
 		api.getFhirWebserviceClientProvider().getLocalWebserviceClient().update(resource);
 	}
 
+	private Predicate<Requester> containsOldRequester(Set<Requester> configureds)
+	{
+		return oldR -> configureds.stream()
+				.anyMatch(configured -> configured.requesterMatches(oldR.toRequesterExtension()));
+	}
+
+	private Predicate<Recipient> containsOldRecipient(Set<Recipient> configureds)
+	{
+		return oldR -> configureds.stream()
+				.anyMatch(configured -> configured.recipientMatches(oldR.toRecipientExtension()));
+	}
+
 	private Predicate<Requester> notContainsNewRequester(Set<Requester> existings)
 	{
 		return newR -> existings.stream().noneMatch(existing -> existing.requesterMatches(newR.toRequesterExtension()));
@@ -268,19 +349,35 @@ public class AuthorizationProvider implements InitializingBean
 		return newR -> existings.stream().noneMatch(existing -> existing.recipientMatches(newR.toRecipientExtension()));
 	}
 
+	private void removeAllAuthorizationExtensions(ActivityDefinition activityDefinition, String messageName,
+			String taskProfile)
+	{
+		List<Extension> extensions = activityDefinition
+				.getExtensionsByUrl(ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION).stream()
+				.filter(extension -> !messageName.equals(((StringType) extension
+						.getExtensionByUrl(ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_MESSAGE_NAME)
+						.getValue()).getValue())
+						&& !taskProfile.equals(((CanonicalType) extension
+								.getExtensionByUrl(
+										ProcessAuthorizationHelper.EXTENSION_PROCESS_AUTHORIZATION_TASK_PROFILE)
+								.getValue()).getValue()))
+				.toList();
+		activityDefinition.setExtension(new ArrayList<>(extensions));
+	}
+
 	private String appendVersion(String url)
 	{
 		return url + "|" + resourcesVersion;
 	}
 
-	private String toRequesterString(List<Requester> requesters)
+	private String toRequesterString(Set<Requester> requesters)
 	{
 		return requesters.stream().map(Requester::toRequesterExtension).map(Extension::getValue)
 				.filter(v -> v instanceof Coding).map(v -> (Coding) v).map(this::toParentOrganizationRoleString)
 				.collect(Collectors.joining(","));
 	}
 
-	private String toRecipientString(List<Recipient> recipients)
+	private String toRecipientString(Set<Recipient> recipients)
 	{
 		return recipients.stream().map(Recipient::toRecipientExtension).map(Extension::getValue)
 				.filter(v -> v instanceof Coding).map(v -> (Coding) v).map(this::toParentOrganizationRoleString)

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/message/SendData.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/message/SendData.java
@@ -20,6 +20,7 @@ import de.medizininformatik_initiative.processes.common.util.ConstantsBase;
 import de.medizininformatik_initiative.processes.common.util.DataSetStatusGenerator;
 import dev.dsf.bpe.v1.ProcessPluginApi;
 import dev.dsf.bpe.v1.activity.AbstractTaskMessageSend;
+import dev.dsf.bpe.v1.constants.NamingSystems;
 import dev.dsf.bpe.v1.variables.Variables;
 import dev.dsf.fhir.client.FhirWebserviceClient;
 import jakarta.ws.rs.WebApplicationException;
@@ -65,7 +66,16 @@ public class SendData extends AbstractTaskMessageSend implements InitializingBea
 		projectIdentifierComponent.setValue(new Identifier()
 				.setSystem(ConstantsBase.NAMINGSYSTEM_MII_PROJECT_IDENTIFIER).setValue(projectIdentifier));
 
-		return Stream.of(documentReferenceComponent, projectIdentifierComponent);
+		String consortiumIdentifier = variables
+				.getString(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_CONSORTIUM_IDENTIFIER);
+
+		Task.ParameterComponent consortiumIdentifierComponent = new Task.ParameterComponent();
+		consortiumIdentifierComponent.getType().addCoding().setSystem(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER)
+				.setCode(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER_VALUE_CONSORTIUM_IDENTIFIER);
+		consortiumIdentifierComponent.setValue(new Reference().setType(ResourceType.Organization.name())
+				.setIdentifier(NamingSystems.OrganizationIdentifier.withValue(consortiumIdentifier)));
+
+		return Stream.of(documentReferenceComponent, projectIdentifierComponent, consortiumIdentifierComponent);
 	}
 
 	@Override

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/service/DownloadData.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/service/DownloadData.java
@@ -62,6 +62,9 @@ public class DownloadData extends AbstractServiceDelegate implements Initializin
 		Task task = variables.getStartTask();
 		String sendingOrganization = task.getRequester().getIdentifier().getValue();
 
+		String consortiumIdentifier = getConsortiumIdentifier(task);
+		variables.setString(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_CONSORTIUM_IDENTIFIER, consortiumIdentifier);
+
 		String projectIdentifier = getProjectIdentifier(task);
 		variables.setString(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_PROJECT_IDENTIFIER, projectIdentifier);
 
@@ -113,6 +116,15 @@ public class DownloadData extends AbstractServiceDelegate implements Initializin
 				.filter(i -> ConstantsBase.NAMINGSYSTEM_MII_PROJECT_IDENTIFIER.equals(i.getSystem()))
 				.map(Identifier::getValue).findFirst()
 				.orElseThrow(() -> new RuntimeException("No project-identifier present in Task.input"));
+	}
+
+	private String getConsortiumIdentifier(Task task)
+	{
+		return api.getTaskHelper()
+				.getFirstInputParameterValue(task, ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER,
+						ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER_VALUE_CONSORTIUM_IDENTIFIER, Reference.class)
+				.orElseThrow(() -> new IllegalArgumentException("No consortium identifier present in Task.input"))
+				.getIdentifier().getValue();
 	}
 
 	private IdType getDocumentReferenceLocation(Task task, String sendingOrganization, String projectIdentifier)

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/service/EncryptAndStoreData.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/service/EncryptAndStoreData.java
@@ -81,6 +81,8 @@ public class EncryptAndStoreData extends AbstractServiceDelegate implements Init
 		Task task = variables.getStartTask();
 		String projectIdentifier = variables
 				.getString(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_PROJECT_IDENTIFIER);
+		String consortiumIdentifier = variables
+				.getString(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_CONSORTIUM_IDENTIFIER);
 		String dmsIdentifier = variables.getString(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_DMS_IDENTIFIER);
 		DocumentReference initialDocumentReference = variables
 				.getResource(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_INITIAL_DOCUMENT_REFERENCE);
@@ -95,7 +97,7 @@ public class EncryptAndStoreData extends AbstractServiceDelegate implements Init
 
 		try
 		{
-			PublicKey publicKey = readPublicKey(dmsIdentifier, projectIdentifier, task.getId());
+			PublicKey publicKey = readPublicKey(consortiumIdentifier, dmsIdentifier, projectIdentifier, task.getId());
 			String localOrganizationIdentifier = getLocalOrganizationIdentifier();
 
 			DocumentReference transferDocumentReference = createAndStoreDocumentReference(projectIdentifier,
@@ -117,7 +119,7 @@ public class EncryptAndStoreData extends AbstractServiceDelegate implements Init
 					transferDocumentReference.getId(), dmsIdentifier, projectIdentifier, task.getId());
 			sendMail(task, projectIdentifier, dmsIdentifier, transferDocumentReference.getIdElement());
 
-			Target target = createTarget(variables, dmsIdentifier);
+			Target target = createTarget(variables, consortiumIdentifier, dmsIdentifier);
 			variables.setTarget(target);
 		}
 		catch (Exception exception)
@@ -142,9 +144,10 @@ public class EncryptAndStoreData extends AbstractServiceDelegate implements Init
 		}
 	}
 
-	private PublicKey readPublicKey(String dmsIdentifier, String projectIdentifier, String taskId)
+	private PublicKey readPublicKey(String consortiumIdentifier, String dmsIdentifier, String projectIdentifier,
+			String taskId)
 	{
-		String url = getEndpointUrl(dmsIdentifier);
+		String url = getEndpointUrl(consortiumIdentifier, dmsIdentifier);
 		Optional<Bundle> publicKeyBundleOptional = keyProvider.readPublicKeyIfExists(url);
 
 		if (publicKeyBundleOptional.isEmpty())
@@ -165,14 +168,9 @@ public class EncryptAndStoreData extends AbstractServiceDelegate implements Init
 		return publicKey;
 	}
 
-	private String getEndpointUrl(String identifier)
+	private String getEndpointUrl(String consortiumIdentifier, String organizationIdentifier)
 	{
-		return api.getEndpointProvider().getEndpointAddress(NamingSystems.OrganizationIdentifier.withValue(
-				ConstantsBase.NAMINGSYSTEM_DSF_ORGANIZATION_IDENTIFIER_MEDICAL_INFORMATICS_INITIATIVE_CONSORTIUM),
-				NamingSystems.OrganizationIdentifier.withValue(identifier),
-				new Coding().setSystem(ConstantsBase.CODESYSTEM_DSF_ORGANIZATION_ROLE)
-						.setCode(ConstantsBase.CODESYSTEM_DSF_ORGANIZATION_ROLE_VALUE_DMS))
-				.orElseThrow(() -> new RuntimeException("Could not find Endpoint for DMS organization"));
+		return getEndpoint(consortiumIdentifier, organizationIdentifier).getAddress();
 	}
 
 	private DocumentReference getDocumentReference(Bundle bundle, String dmsIdentifier, String projectIdentifier,
@@ -410,21 +408,21 @@ public class EncryptAndStoreData extends AbstractServiceDelegate implements Init
 				transferBinaryReferenceList, variables);
 	}
 
-	private Target createTarget(Variables variables, String dmsIdentifier)
+	private Target createTarget(Variables variables, String consortiumIdentifier, String dmsIdentifier)
 	{
-		Endpoint endpoint = getEndpoint(dmsIdentifier);
+		Endpoint endpoint = getEndpoint(consortiumIdentifier, dmsIdentifier);
 		return variables.createTarget(dmsIdentifier, getEndpointIdentifierValue(endpoint), endpoint.getAddress());
 	}
 
-	private Endpoint getEndpoint(String identifier)
+	private Endpoint getEndpoint(String consortiumIdentifier, String organizationIdentifier)
 	{
-		return api.getEndpointProvider().getEndpoint(NamingSystems.OrganizationIdentifier.withValue(
-				ConstantsBase.NAMINGSYSTEM_DSF_ORGANIZATION_IDENTIFIER_MEDICAL_INFORMATICS_INITIATIVE_CONSORTIUM),
-				NamingSystems.OrganizationIdentifier.withValue(identifier),
-				new Coding().setSystem(ConstantsBase.CODESYSTEM_DSF_ORGANIZATION_ROLE)
-						.setCode(ConstantsBase.CODESYSTEM_DSF_ORGANIZATION_ROLE_VALUE_DMS))
-				.orElseThrow(() -> new RuntimeException(
-						"Could not find Endpoint of organization with identifier '" + identifier + "'"));
+		return api.getEndpointProvider()
+				.getEndpoint(NamingSystems.OrganizationIdentifier.withValue(consortiumIdentifier),
+						NamingSystems.OrganizationIdentifier.withValue(organizationIdentifier),
+						new Coding().setSystem(ConstantsBase.CODESYSTEM_DSF_ORGANIZATION_ROLE)
+								.setCode(ConstantsBase.CODESYSTEM_DSF_ORGANIZATION_ROLE_VALUE_DMS))
+				.orElseThrow(() -> new RuntimeException("Could not find Endpoint of organization with identifier '"
+						+ organizationIdentifier + "' in  consortium '" + consortiumIdentifier + "'"));
 	}
 
 	private String getEndpointIdentifierValue(Endpoint endpoint)

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/service/ReadData.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/service/ReadData.java
@@ -27,6 +27,7 @@ import de.medizininformatik_initiative.processes.common.fhir.client.logging.Data
 import de.medizininformatik_initiative.processes.common.util.ConstantsBase;
 import dev.dsf.bpe.v1.ProcessPluginApi;
 import dev.dsf.bpe.v1.activity.AbstractServiceDelegate;
+import dev.dsf.bpe.v1.constants.NamingSystems;
 import dev.dsf.bpe.v1.variables.Variables;
 
 public class ReadData extends AbstractServiceDelegate implements InitializingBean
@@ -60,6 +61,7 @@ public class ReadData extends AbstractServiceDelegate implements InitializingBea
 	{
 		Task task = variables.getStartTask();
 		String dmsIdentifier = getDmsIdentifier(task);
+		String consortiumIdentifier = getConsortiumIdentifier(task);
 		String projectIdentifier = getProjectIdentifier(task, dmsIdentifier);
 
 		logger.info(
@@ -74,6 +76,8 @@ public class ReadData extends AbstractServiceDelegate implements InitializingBea
 
 			variables.setString(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_PROJECT_IDENTIFIER, projectIdentifier);
 			variables.setString(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_DMS_IDENTIFIER, dmsIdentifier);
+			variables.setString(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_CONSORTIUM_IDENTIFIER,
+					consortiumIdentifier);
 			variables.setResource(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_INITIAL_DOCUMENT_REFERENCE,
 					documentReference);
 			variables.setResourceList(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_INITIAL_DATA_RESOURCES, resources);
@@ -109,13 +113,22 @@ public class ReadData extends AbstractServiceDelegate implements InitializingBea
 		return identifiers.get(0);
 	}
 
+	private String getConsortiumIdentifier(Task task)
+	{
+		return api.getTaskHelper()
+				.getFirstInputParameterValue(task, ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER,
+						ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER_VALUE_CONSORTIUM_IDENTIFIER, Reference.class)
+				.orElse(new Reference().setIdentifier(NamingSystems.OrganizationIdentifier.withValue(
+						ConstantsBase.NAMINGSYSTEM_DSF_ORGANIZATION_IDENTIFIER_MEDICAL_INFORMATICS_INITIATIVE_CONSORTIUM)))
+				.getIdentifier().getValue();
+	}
+
 	private String getDmsIdentifier(Task task)
 	{
 		return api.getTaskHelper()
 				.getFirstInputParameterValue(task, ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER,
 						ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER_VALUE_DMS_IDENTIFIER, Reference.class)
-				.orElseThrow(
-						() -> new IllegalArgumentException("No coordinating site identifier present in Task.input"))
+				.orElseThrow(() -> new IllegalArgumentException("No DMS identifier present in Task.input"))
 				.getIdentifier().getValue();
 	}
 

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/service/SelectTargetDic.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/service/SelectTargetDic.java
@@ -6,6 +6,7 @@ import org.hl7.fhir.r4.model.Endpoint;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Task;
 
+import de.medizininformatik_initiative.process.data_transfer.ConstantsDataTransfer;
 import de.medizininformatik_initiative.processes.common.util.ConstantsBase;
 import dev.dsf.bpe.v1.ProcessPluginApi;
 import dev.dsf.bpe.v1.activity.AbstractServiceDelegate;
@@ -24,8 +25,10 @@ public class SelectTargetDic extends AbstractServiceDelegate
 	protected void doExecute(DelegateExecution execution, Variables variables)
 	{
 		Task task = variables.getStartTask();
+		String consortiumIdentifier = variables
+				.getString(ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_CONSORTIUM_IDENTIFIER);
 		Identifier dicIdentifier = getDicOrganizationIdentifier(task);
-		Endpoint dicEndpoint = getDicEndpoint(dicIdentifier);
+		Endpoint dicEndpoint = getDicEndpoint(consortiumIdentifier, dicIdentifier);
 		Target dicTarget = createTarget(variables, dicIdentifier, dicEndpoint);
 
 		variables.setTarget(dicTarget);
@@ -36,10 +39,9 @@ public class SelectTargetDic extends AbstractServiceDelegate
 		return task.getRequester().getIdentifier();
 	}
 
-	private Endpoint getDicEndpoint(Identifier dicIdentifier)
+	private Endpoint getDicEndpoint(String consortiumIdentifier, Identifier dicIdentifier)
 	{
-		Identifier parentIdentifier = NamingSystems.OrganizationIdentifier.withValue(
-				ConstantsBase.NAMINGSYSTEM_DSF_ORGANIZATION_IDENTIFIER_MEDICAL_INFORMATICS_INITIATIVE_CONSORTIUM);
+		Identifier parentIdentifier = NamingSystems.OrganizationIdentifier.withValue(consortiumIdentifier);
 		Coding role = new Coding().setSystem(ConstantsBase.CODESYSTEM_DSF_ORGANIZATION_ROLE)
 				.setCode(ConstantsBase.CODESYSTEM_DSF_ORGANIZATION_ROLE_VALUE_DIC);
 		return api.getEndpointProvider().getEndpoint(parentIdentifier, dicIdentifier, role)

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/spring/config/TransferDataConfig.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/spring/config/TransferDataConfig.java
@@ -1,5 +1,7 @@
 package de.medizininformatik_initiative.process.data_transfer.spring.config;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -9,6 +11,7 @@ import org.springframework.context.annotation.Scope;
 
 import de.medizininformatik_initiative.process.data_transfer.DataTransferProcessPluginDefinition;
 import de.medizininformatik_initiative.process.data_transfer.DataTransferProcessPluginDeploymentStateListener;
+import de.medizininformatik_initiative.process.data_transfer.authorization.AuthorizationProvider;
 import de.medizininformatik_initiative.process.data_transfer.message.SendData;
 import de.medizininformatik_initiative.process.data_transfer.message.SendReceipt;
 import de.medizininformatik_initiative.process.data_transfer.service.DecryptValidateAndInsertData;
@@ -68,6 +71,16 @@ public class TransferDataConfig
 	@Value("${de.medizininformatik.initiative.dms.public.key:#{null}}")
 	private String dmsPublicKeyFile;
 
+	@ProcessDocumentation(required = true, processNames = { "medizininformatik-initiativede_dataSend",
+			"medizininformatik-initiativede_dataReceive" }, description = "Adds additional allowed data-set senders to the authorization rules based on the `<parent-organization>|<role> definition", recommendation = "If this env variable is set, 'DE_MEDIZININFORMATIK_INITIATIVE_DATA_TRANSFER_PROCESS_AUTHORIZATION_ADDITIONALLY_ALLOWED_RECEIVERS' should be set as well", example = "nct.dkfz.de|DIC")
+	@Value("#{'${de.medizininformatik.initiative.data.transfer.process.authorization.additionally.allowed.senders:medizininformatik-initiative.de|DIC}'.trim().split('(,[ ]?)|(\\n)')}")
+	private List<String> additionallyAllowedSenders;
+
+	@ProcessDocumentation(required = true, processNames = { "medizininformatik-initiativede_dataSend",
+			"medizininformatik-initiativede_dataReceive" }, description = "Adds additional allowed data-set receivers to the authorization rules based on the `<parent-organization>|<role> definition", recommendation = "If this env variable is set, 'DE_MEDIZININFORMATIK_INITIATIVE_DATA_TRANSFER_PROCESS_AUTHORIZATION_ADDITIONALLY_ALLOWED_SENDERS' should be set as well", example = "nct.dkfz.de|DMS")
+	@Value("#{'${de.medizininformatik.initiative.data.transfer.process.authorization.additionally.allowed.receivers:medizininformatik-initiative.de|DMS}'.trim().split('(,[ ]?)|(\\n)')}")
+	private List<String> additionallyAllowedReceivers;
+
 	// all Processes
 
 	@Bean
@@ -108,10 +121,20 @@ public class TransferDataConfig
 
 	@Bean
 	@Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+	public AuthorizationProvider authorizationProvider()
+	{
+		String resourcesVersion = new DataTransferProcessPluginDefinition().getResourceVersion();
+		return new AuthorizationProvider(api, resourcesVersion, additionallyAllowedSenders,
+				additionallyAllowedReceivers);
+	}
+
+	@Bean
+	@Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
 	public ProcessPluginDeploymentStateListener dataTransferProcessPluginDeploymentStateListener()
 	{
 		return new DataTransferProcessPluginDeploymentStateListener(api, dicFhirClientConfig.fhirClientFactory(),
-				dmsFhirClientConfig.fhirClientFactory(), keyProviderDms(), metadataResourceConverter());
+				dmsFhirClientConfig.fhirClientFactory(), keyProviderDms(), metadataResourceConverter(),
+				authorizationProvider());
 	}
 
 	// dataSend

--- a/src/main/java/de/medizininformatik_initiative/process/data_transfer/spring/config/TransferDataConfig.java
+++ b/src/main/java/de/medizininformatik_initiative/process/data_transfer/spring/config/TransferDataConfig.java
@@ -72,12 +72,12 @@ public class TransferDataConfig
 	private String dmsPublicKeyFile;
 
 	@ProcessDocumentation(required = true, processNames = { "medizininformatik-initiativede_dataSend",
-			"medizininformatik-initiativede_dataReceive" }, description = "Adds additional allowed data-set senders to the authorization rules based on the `<parent-organization>|<role> definition", recommendation = "If this env variable is set, 'DE_MEDIZININFORMATIK_INITIATIVE_DATA_TRANSFER_PROCESS_AUTHORIZATION_ADDITIONALLY_ALLOWED_RECEIVERS' should be set as well", example = "nct.dkfz.de|DIC")
+			"medizininformatik-initiativede_dataReceive" }, description = "Adds additional allowed data-set senders to the authorization rules based on the `<consortium-identifier>|<role> definition", recommendation = "If this env variable is set, 'DE_MEDIZININFORMATIK_INITIATIVE_DATA_TRANSFER_PROCESS_AUTHORIZATION_ADDITIONALLY_ALLOWED_RECEIVERS' should be set as well", example = "nct.dkfz.de|DIC")
 	@Value("#{'${de.medizininformatik.initiative.data.transfer.process.authorization.additionally.allowed.senders:medizininformatik-initiative.de|DIC}'.trim().split('(,[ ]?)|(\\n)')}")
 	private List<String> additionallyAllowedSenders;
 
 	@ProcessDocumentation(required = true, processNames = { "medizininformatik-initiativede_dataSend",
-			"medizininformatik-initiativede_dataReceive" }, description = "Adds additional allowed data-set receivers to the authorization rules based on the `<parent-organization>|<role> definition", recommendation = "If this env variable is set, 'DE_MEDIZININFORMATIK_INITIATIVE_DATA_TRANSFER_PROCESS_AUTHORIZATION_ADDITIONALLY_ALLOWED_SENDERS' should be set as well", example = "nct.dkfz.de|DMS")
+			"medizininformatik-initiativede_dataReceive" }, description = "Adds additional allowed data-set receivers to the authorization rules based on the `<consortium-identifier>|<role> definition", recommendation = "If this env variable is set, 'DE_MEDIZININFORMATIK_INITIATIVE_DATA_TRANSFER_PROCESS_AUTHORIZATION_ADDITIONALLY_ALLOWED_SENDERS' should be set as well", example = "nct.dkfz.de|DMS")
 	@Value("#{'${de.medizininformatik.initiative.data.transfer.process.authorization.additionally.allowed.receivers:medizininformatik-initiative.de|DMS}'.trim().split('(,[ ]?)|(\\n)')}")
 	private List<String> additionallyAllowedReceivers;
 

--- a/src/main/resources/fhir/CodeSystem/data-transfer.xml
+++ b/src/main/resources/fhir/CodeSystem/data-transfer.xml
@@ -22,6 +22,11 @@
 	<versionNeeded value="false" />
 	<content value="complete" />
 	<concept>
+		<code value="consortium-identifier" />
+		<display value="Consortium Identifier" />
+		<definition value="Organization identifier of the consortium the DMS belongs to" />
+	</concept>
+	<concept>
 		<code value="dms-identifier" />
 		<display value="DMS Identifier" />
 		<definition value="Organization identifier of a DMS" />

--- a/src/main/resources/fhir/StructureDefinition/task-data-send-start.xml
+++ b/src/main/resources/fhir/StructureDefinition/task-data-send-start.xml
@@ -28,7 +28,7 @@
 		<element id="Task.input">
 			<path value="Task.input"/>
 			<min value="3"/>
-			<max value="4"/>
+			<max value="5"/>
 		</element>
 		<element id="Task.input:message-name">
 			<path value="Task.input"/>
@@ -42,6 +42,49 @@
 			<path value="Task.input"/>
 			<sliceName value="correlation-key"/>
 			<max value="0"/>
+		</element>
+		<element id="Task.input:consortium-identifier">
+			<path value="Task.input"/>
+			<sliceName value="consortium-identifier"/>
+			<min value="0"/>
+			<max value="1"/>
+		</element>
+		<element id="Task.input:consortium-identifier.type">
+			<path value="Task.input.type"/>
+			<binding>
+				<strength value="required"/>
+				<valueSet value="http://medizininformatik-initiative.de/fhir/ValueSet/data-transfer|#{version}"/>
+			</binding>
+		</element>
+		<element id="Task.input:consortium-identifier.type.coding">
+			<path value="Task.input.type.coding"/>
+			<min value="1"/>
+			<max value="1"/>
+		</element>
+		<element id="Task.input:consortium-identifier.type.coding.system">
+			<path value="Task.input.type.coding.system"/>
+			<min value="1"/>
+			<fixedUri value="http://medizininformatik-initiative.de/fhir/CodeSystem/data-transfer"/>
+		</element>
+		<element id="Task.input:consortium-identifier.type.coding.code">
+			<path value="Task.input.type.coding.code"/>
+			<min value="1"/>
+			<fixedCode value="consortium-identifier"/>
+		</element>
+		<element id="Task.input:consortium-identifier.value[x]">
+			<path value="Task.input.value[x]"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://dsf.dev/fhir/StructureDefinition/organization"/>
+			</type>
+		</element>
+		<element id="Task.input:consortium-identifier.value[x].reference">
+			<path value="Task.input.value[x].reference"/>
+			<max value="0"/>
+		</element>
+		<element id="Task.input:consortium-identifier.value[x].identifier">
+			<path value="Task.input.value[x].identifier"/>
+			<min value="1"/>
 		</element>
 		<element id="Task.input:dms-identifier">
 			<path value="Task.input"/>

--- a/src/main/resources/fhir/StructureDefinition/task-data-send.xml
+++ b/src/main/resources/fhir/StructureDefinition/task-data-send.xml
@@ -27,8 +27,8 @@
 		</element>
 		<element id="Task.input">
 			<path value="Task.input"/>
-			<min value="3"/>
-			<max value="4"/>
+			<min value="4"/>
+			<max value="5"/>
 		</element>
 		<element id="Task.input:message-name">
 			<path value="Task.input"/>
@@ -48,48 +48,91 @@
 			<sliceName value="correlation-key"/>
 			<max value="0"/>
 		</element>
+		<element id="Task.input:consortium-identifier">
+			<path value="Task.input"/>
+			<sliceName value="consortium-identifier"/>
+			<min value="1"/>
+			<max value="1"/>
+		</element>
+		<element id="Task.input:consortium-identifier.type">
+			<path value="Task.input.type"/>
+			<binding>
+				<strength value="required"/>
+				<valueSet value="http://medizininformatik-initiative.de/fhir/ValueSet/data-transfer|#{version}"/>
+			</binding>
+		</element>
+		<element id="Task.input:consortium-identifier.type.coding">
+			<path value="Task.input.type.coding"/>
+			<min value="1"/>
+			<max value="1"/>
+		</element>
+		<element id="Task.input:consortium-identifier.type.coding.system">
+			<path value="Task.input.type.coding.system"/>
+			<min value="1"/>
+			<fixedUri value="http://medizininformatik-initiative.de/fhir/CodeSystem/data-transfer"/>
+		</element>
+		<element id="Task.input:consortium-identifier.type.coding.code">
+			<path value="Task.input.type.coding.code"/>
+			<min value="1"/>
+			<fixedCode value="consortium-identifier"/>
+		</element>
+		<element id="Task.input:consortium-identifier.value[x]">
+			<path value="Task.input.value[x]"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://dsf.dev/fhir/StructureDefinition/organization"/>
+			</type>
+		</element>
+		<element id="Task.input:consortium-identifier.value[x].reference">
+			<path value="Task.input.value[x].reference"/>
+			<max value="0"/>
+		</element>
+		<element id="Task.input:consortium-identifier.value[x].identifier">
+			<path value="Task.input.value[x].identifier"/>
+			<min value="1"/>
+		</element>
 		<element id="Task.input:project-identifier">
-			<path value="Task.input" />
-			<sliceName value="project-identifier" />
-			<min value="1" />
-			<max value="1" />
+			<path value="Task.input"/>
+			<sliceName value="project-identifier"/>
+			<min value="1"/>
+			<max value="1"/>
 		</element>
 		<element id="Task.input:project-identifier.type">
-			<path value="Task.input.type" />
+			<path value="Task.input.type"/>
 			<binding>
-				<strength value="required" />
-				<valueSet value="http://medizininformatik-initiative.de/fhir/ValueSet/data-transfer|#{version}" />
+				<strength value="required"/>
+				<valueSet value="http://medizininformatik-initiative.de/fhir/ValueSet/data-transfer|#{version}"/>
 			</binding>
 		</element>
 		<element id="Task.input:project-identifier.type.coding">
-			<path value="Task.input.type.coding" />
-			<min value="1" />
-			<max value="1" />
+			<path value="Task.input.type.coding"/>
+			<min value="1"/>
+			<max value="1"/>
 		</element>
 		<element id="Task.input:project-identifier.type.coding.system">
-			<path value="Task.input.type.coding.system" />
-			<min value="1" />
-			<fixedUri value="http://medizininformatik-initiative.de/fhir/CodeSystem/data-transfer" />
+			<path value="Task.input.type.coding.system"/>
+			<min value="1"/>
+			<fixedUri value="http://medizininformatik-initiative.de/fhir/CodeSystem/data-transfer"/>
 		</element>
 		<element id="Task.input:project-identifier.type.coding.code">
-			<path value="Task.input.type.coding.code" />
-			<min value="1" />
-			<fixedCode value="project-identifier" />
+			<path value="Task.input.type.coding.code"/>
+			<min value="1"/>
+			<fixedCode value="project-identifier"/>
 		</element>
 		<element id="Task.input:project-identifier.value[x]">
-			<path value="Task.input.value[x]" />
+			<path value="Task.input.value[x]"/>
 			<type>
-				<code value="Identifier" />
+				<code value="Identifier"/>
 			</type>
 		</element>
 		<element id="Task.input:project-identifier.value[x].system">
-			<path value="Task.input.value[x].system" />
-			<min value="1" />
-			<fixedUri value="http://medizininformatik-initiative.de/sid/project-identifier" />
+			<path value="Task.input.value[x].system"/>
+			<min value="1"/>
+			<fixedUri value="http://medizininformatik-initiative.de/sid/project-identifier"/>
 		</element>
 		<element id="Task.input:project-identifier.value[x].value">
-			<path value="Task.input.value[x].value" />
-			<min value="1" />
+			<path value="Task.input.value[x].value"/>
+			<min value="1"/>
 		</element>
 		<element id="Task.input:document-reference-location">
 			<path value="Task.input"/>
@@ -171,7 +214,7 @@
 		</element>
 		<element id="Task.output:document-reference-location.value[x].reference">
 			<path value="Task.output.value[x].reference"/>
-            <min value="1"/>
+			<min value="1"/>
 		</element>
 		<element id="Task.output:document-reference-location.value[x].identifier">
 			<path value="Task.output.value[x].identifier"/>
@@ -182,23 +225,24 @@
 			<sliceName value="data-set-status"/>
 		</element>
 		<element id="Task.output:data-set-status.extension">
-			<path value="Task.output.extension" />
+			<path value="Task.output.extension"/>
 			<slicing>
 				<discriminator>
-					<type value="value" />
-					<path value="url" />
+					<type value="value"/>
+					<path value="url"/>
 				</discriminator>
-				<rules value="open" />
+				<rules value="open"/>
 			</slicing>
 		</element>
 		<element id="Task.output:data-set-status.extension:extension-data-set-status-error">
-			<path value="Task.output.extension" />
-			<sliceName value="extension-data-set-status-error" />
-			<min value="0" />
-			<max value="1" />
+			<path value="Task.output.extension"/>
+			<sliceName value="extension-data-set-status-error"/>
+			<min value="0"/>
+			<max value="1"/>
 			<type>
-				<code value="Extension" />
-				<profile value="http://medizininformatik-initiative.de/fhir/StructureDefinition/extension-data-set-status-error" />
+				<code value="Extension"/>
+				<profile
+						value="http://medizininformatik-initiative.de/fhir/StructureDefinition/extension-data-set-status-error"/>
 			</type>
 		</element>
 		<element id="Task.output:data-set-status.type">
@@ -239,7 +283,8 @@
 			<min value="1"/>
 			<binding>
 				<strength value="required"/>
-				<valueSet value="http://medizininformatik-initiative.de/fhir/ValueSet/data-set-status-receive|#{version}"/>
+				<valueSet
+						value="http://medizininformatik-initiative.de/fhir/ValueSet/data-set-status-receive|#{version}"/>
 			</binding>
 		</element>
 	</differential>

--- a/src/main/resources/fhir/Task/task-data-send-start.xml
+++ b/src/main/resources/fhir/Task/task-data-send-start.xml
@@ -1,65 +1,81 @@
 <Task xmlns="http://hl7.org/fhir">
-   <meta>
-      <profile value="http://medizininformatik-initiative.de/fhir/StructureDefinition/task-data-send-start|#{version}" />
-   </meta>
-   <identifier>
-      <system value="http://dsf.dev/sid/task-identifier"/>
-      <value value="http://medizininformatik-initiative.de/bpe/Process/dataSend/#{version}/dataSendStart"/>
-   </identifier>
-   <instantiatesCanonical value="http://medizininformatik-initiative.de/bpe/Process/dataSend|#{version}"/>
-   <status value="draft" />
-   <intent value="order" />
-   <authoredOn value="#{date}" />
-   <requester>
-      <type value="Organization" />
-      <identifier>
-         <system value="http://dsf.dev/sid/organization-identifier" />
-         <value value="#{organization}" />
-      </identifier>
-   </requester>
-   <restriction>
-      <recipient>
-         <type value="Organization" />
-         <identifier>
-            <system value="http://dsf.dev/sid/organization-identifier" />
-            <value value="#{organization}" />
-         </identifier>
-      </recipient>
-   </restriction>
-   <input>
-      <type>
-         <coding>
-            <system value="http://dsf.dev/fhir/CodeSystem/bpmn-message" />
-            <code value="message-name" />
-         </coding>
-      </type>
-      <valueString value="dataSendStart" />
-   </input>
-   <input>
-      <type>
-         <coding>
-            <system value="http://medizininformatik-initiative.de/fhir/CodeSystem/data-transfer" />
-            <code value="dms-identifier" />
-         </coding>
-      </type>
-      <valueReference>
-         <type value="Organization" />
-         <identifier>
-            <system value="http://dsf.dev/sid/organization-identifier" />
-            <value value="#{organization}" />
-         </identifier>
-      </valueReference>
-   </input>
-   <input>
-      <type>
-         <coding>
-            <system value="http://medizininformatik-initiative.de/fhir/CodeSystem/data-transfer" />
-            <code value="project-identifier" />
-         </coding>
-      </type>
-      <valueIdentifier>
-            <system value="http://medizininformatik-initiative.de/sid/project-identifier" />
-            <value value="Example_Project" />
-      </valueIdentifier>
-   </input>
+	<meta>
+		<profile
+				value="http://medizininformatik-initiative.de/fhir/StructureDefinition/task-data-send-start|#{version}"/>
+	</meta>
+	<identifier>
+		<system value="http://dsf.dev/sid/task-identifier"/>
+		<value value="http://medizininformatik-initiative.de/bpe/Process/dataSend/#{version}/dataSendStart"/>
+	</identifier>
+	<instantiatesCanonical value="http://medizininformatik-initiative.de/bpe/Process/dataSend|#{version}"/>
+	<status value="draft"/>
+	<intent value="order"/>
+	<authoredOn value="#{date}"/>
+	<requester>
+		<type value="Organization"/>
+		<identifier>
+			<system value="http://dsf.dev/sid/organization-identifier"/>
+			<value value="#{organization}"/>
+		</identifier>
+	</requester>
+	<restriction>
+		<recipient>
+			<type value="Organization"/>
+			<identifier>
+				<system value="http://dsf.dev/sid/organization-identifier"/>
+				<value value="#{organization}"/>
+			</identifier>
+		</recipient>
+	</restriction>
+	<input>
+		<type>
+			<coding>
+				<system value="http://dsf.dev/fhir/CodeSystem/bpmn-message"/>
+				<code value="message-name"/>
+			</coding>
+		</type>
+		<valueString value="dataSendStart"/>
+	</input>
+	<input>
+		<type>
+			<coding>
+				<system value="http://medizininformatik-initiative.de/fhir/CodeSystem/data-transfer"/>
+				<code value="project-identifier"/>
+			</coding>
+		</type>
+		<valueIdentifier>
+			<system value="http://medizininformatik-initiative.de/sid/project-identifier"/>
+			<value value="Example_Project"/>
+		</valueIdentifier>
+	</input>
+	<input>
+		<type>
+			<coding>
+				<system value="http://medizininformatik-initiative.de/fhir/CodeSystem/data-transfer"/>
+				<code value="dms-identifier"/>
+			</coding>
+		</type>
+		<valueReference>
+			<type value="Organization"/>
+			<identifier>
+				<system value="http://dsf.dev/sid/organization-identifier"/>
+				<value value="#{organization}"/>
+			</identifier>
+		</valueReference>
+	</input>
+	<input>
+		<type>
+			<coding>
+				<system value="http://medizininformatik-initiative.de/fhir/CodeSystem/data-transfer"/>
+				<code value="consortium-identifier"/>
+			</coding>
+		</type>
+		<valueReference>
+			<type value="Organization"/>
+			<identifier>
+				<system value="http://dsf.dev/sid/organization-identifier"/>
+				<value value="#{organization}"/>
+			</identifier>
+		</valueReference>
+	</input>
 </Task>

--- a/src/test/java/de/medizininformatik_initiative/process/data_transfer/fhir/profile/TaskProfileTest.java
+++ b/src/test/java/de/medizininformatik_initiative/process/data_transfer/fhir/profile/TaskProfileTest.java
@@ -61,6 +61,22 @@ public class TaskProfileTest
 	}
 
 	@Test
+	public void testTaskStartDataSendValidWithConsortium()
+	{
+		Task task = createValidTaskDataSendStart();
+		task.addInput().setValue(new Reference().setIdentifier(NamingSystems.OrganizationIdentifier.withValue(
+				ConstantsBase.NAMINGSYSTEM_DSF_ORGANIZATION_IDENTIFIER_MEDICAL_INFORMATICS_INITIATIVE_CONSORTIUM)))
+				.getType().addCoding().setSystem(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER)
+				.setCode(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER_VALUE_CONSORTIUM_IDENTIFIER);
+
+		ValidationResult result = resourceValidator.validate(task);
+		ValidationSupportRule.logValidationMessages(logger, result);
+
+		assertEquals(0, result.getMessages().stream().filter(m -> ResultSeverityEnum.ERROR.equals(m.getSeverity())
+				|| ResultSeverityEnum.FATAL.equals(m.getSeverity())).count());
+	}
+
+	@Test
 	public void testTaskStartDataSendValidWithReportStatusErrorOutput()
 	{
 		Task task = createValidTaskDataSendStart();
@@ -166,17 +182,21 @@ public class TaskProfileTest
 		task.addInput().setValue(new StringType(ConstantsDataTransfer.PROFILE_TASK_DATA_SEND_MESSAGE_NAME)).getType()
 				.addCoding(CodeSystems.BpmnMessage.messageName());
 
+		task.addInput().setValue(new Reference().setIdentifier(NamingSystems.OrganizationIdentifier.withValue(
+				ConstantsBase.NAMINGSYSTEM_DSF_ORGANIZATION_IDENTIFIER_MEDICAL_INFORMATICS_INITIATIVE_CONSORTIUM)))
+				.getType().addCoding().setSystem(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER)
+				.setCode(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER_VALUE_CONSORTIUM_IDENTIFIER);
+		task.addInput()
+				.setValue(new Identifier().setSystem(ConstantsBase.NAMINGSYSTEM_MII_PROJECT_IDENTIFIER)
+						.setValue("Test_PROJECT"))
+				.getType().addCoding().setSystem(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER)
+				.setCode(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER_VALUE_PROJECT_IDENTIFIER);
 		task.addInput()
 				.setValue(new Reference()
 						.setReference("https://dsf-dic.de/fhir/DocumentReference/" + UUID.randomUUID().toString())
 						.setType(ResourceType.DocumentReference.name()))
 				.getType().addCoding().setSystem(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER)
 				.setCode(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER_VALUE_DOCUMENT_REFERENCE_LOCATION);
-		task.addInput()
-				.setValue(new Identifier().setSystem(ConstantsBase.NAMINGSYSTEM_MII_PROJECT_IDENTIFIER)
-						.setValue("Test_PROJECT"))
-				.getType().addCoding().setSystem(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER)
-				.setCode(ConstantsDataTransfer.CODESYSTEM_DATA_TRANSFER_VALUE_PROJECT_IDENTIFIER);
 		return task;
 	}
 


### PR DESCRIPTION
The process authorization rules can now be configured, resulting in dynamically updated ActivityDefinition resources. The configuration is based on two new environment variables for specifying allowed senders and receivers. These variables accept lists of entries in the format `<consortia-identifier>|<role>`:
- `DE_MEDIZININFORMATIK_INITIATIVE_DATA_TRANSFER_PROCESS_AUTHORIZATION_ADDITIONALLY_ALLOWED_SENDERS`
- `DE_MEDIZININFORMATIK_INITIATIVE_DATA_TRANSFER_PROCESS_AUTHORIZATION_ADDITIONALLY_ALLOWED_RECEIVERS`

The MII consortium is configured by default as part of the process ActivityDefinition resources. Any additional consortia must be configured explicitly using the above environment variables.

Additionally, the task to initiate the process now supports a new optional input for specifying a consortium identifier. When provided, the corresponding DMS endpoint will be determined based on this identifier. If no consortium identifier is specified, the system falls back to using the MII consortium identifier by default.

resolves #46 